### PR TITLE
Taking account of os_validate_certs defined in default/main.yml to permit cloud resource creation without ssl verification

### DIFF
--- a/tasks/create_domain.yml
+++ b/tasks/create_domain.yml
@@ -6,3 +6,4 @@
     name: "{{ item_domain.name }}"
     description: "{{ item_domain.description|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_flavor.yml
+++ b/tasks/create_flavor.yml
@@ -11,3 +11,4 @@
     ephemeral: "{{ item_flavor.ephemeral|default(omit) }}"
     rxtx_factor: "{{ item_flavor.rxtx_factor|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_image.yml
+++ b/tasks/create_image.yml
@@ -3,6 +3,7 @@
     - os_image_facts:
         cloud: "{{ item_cloud.oscc_cloud|default(item_cloud.name) }}"
         image: "{{ item_image.name }}"
+        validate_certs: "{{ os_validate_certs }}"
     - get_url:
         url: "{{ item_image.download_image_url }}"
         dest: "{{ item_image.download_image_dest|default(download_image_dest) }}"
@@ -25,3 +26,4 @@
     properties: "{{ item_image.properties|default(omit) }}"
     is_public: "{{ item_image.is_public|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_keypair.yml
+++ b/tasks/create_keypair.yml
@@ -7,3 +7,4 @@
     public_key: "{{ item_keypair.public_key|default(omit) }}"
     public_key_file: "{{ item_keypair.public_key_file|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_network.yml
+++ b/tasks/create_network.yml
@@ -7,3 +7,4 @@
     external: "{{ item_network.external|default(omit) }}"
     project: "{{ item_network.project|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_project.yml
+++ b/tasks/create_project.yml
@@ -7,3 +7,4 @@
     description: "{{ item_project.description|default(omit) }}"
     domain: "{{ item_project.domain|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_quota.yml
+++ b/tasks/create_quota.yml
@@ -5,4 +5,12 @@
     OS_CLOUD: "{{ item_cloud.name }}"
     OS_REGION_NAME: "{{ item_cloud.region_name|default('')}}"
   with_dict: "{{ item_quota }}"
-  when: item.key != 'name'
+  when: item.key != 'name' and os_validate_certs == 'yes'
+
+- name: "Processing quotas for project {{ item_quota.name }}"
+  command: openstack --insecure quota set --"{{ item.key }}" "{{ item.value }}" "{{ item_quota.name }}"
+  environment:
+    OS_CLOUD: "{{ item_cloud.name }}"
+    OS_REGION_NAME: "{{ item_cloud.region_name|default('')}}"
+  with_dict: "{{ item_quota }}"
+  when: item.key != 'name' and os_validate_certs == 'no'

--- a/tasks/create_role.yml
+++ b/tasks/create_role.yml
@@ -4,3 +4,4 @@
     cloud: "{{ item_cloud.oscc_cloud|default(item_cloud.name) }}"
     state: "{{ item_role.state|default(omit) }}"
     name: "{{ item_role.name }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_router.yml
+++ b/tasks/create_router.yml
@@ -10,3 +10,4 @@
     external_fixed_ips: "{{ item_router.external_fixed_ips|default(omit) }}"
     interfaces: "{{ item_router.interfaces|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_security_group.yml
+++ b/tasks/create_security_group.yml
@@ -5,3 +5,4 @@
     name: "{{ item_security_group.name }}"
     description: "{{ item_security_group.description|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_security_group_rule.yml
+++ b/tasks/create_security_group_rule.yml
@@ -12,3 +12,4 @@
     remote_group: "{{ item_security_group_rule.remote_group|default(omit) }}"
     remote_ip_prefix: "{{ item_security_group_rule.remote_ip_prefix|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_server.yml
+++ b/tasks/create_server.yml
@@ -30,6 +30,7 @@
     volume_size: "{{ item_server.volume_size|default(omit) }}"
     volumes: "{{ item_server.volumes|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"
   with_sequence: start=1 end={{ item_server.node_count|default(1) }} format=%02x
   register: os_server_result
 

--- a/tasks/create_subnet.yml
+++ b/tasks/create_subnet.yml
@@ -8,3 +8,4 @@
     cidr: "{{ item_subnet.cidr }}"
     dns_nameservers: "{{ item_subnet.dns_nameservers|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -9,3 +9,4 @@
     domain: "{{ item_user.domain|default(omit) }}"
     default_project: "{{ item_user.default_project|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_user_role.yml
+++ b/tasks/create_user_role.yml
@@ -7,3 +7,4 @@
     domain: "{{ item_user_role.domain|default(omit) }}"
     project: "{{ item_user_role.project|default(omit) }}"
     user: "{{ item_user_role.user|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/create_volume.yml
+++ b/tasks/create_volume.yml
@@ -11,3 +11,4 @@
     snapshot_id: "{{ item_volume.snapshot_id|default(omit) }}"
     volume_type: "{{ item_volume.volume_type|default(omit) }}"
     region_name: "{{ item_cloud.region_name|default(omit) }}"
+    validate_certs: "{{ os_validate_certs }}"

--- a/tasks/generate_keypair.yml
+++ b/tasks/generate_keypair.yml
@@ -15,4 +15,5 @@
         state: present
         name: "{{ cl_generated_keypair_name }}"
         public_key_file: "{{ cl_generated_keypair_public_key_filename }}"
+        validate_certs: "{{ os_validate_certs }}"
   when: generate_keypair|bool


### PR DESCRIPTION
I added validate_certs: "{{ os_validate_certs }}" in every os_* calls and made a test on os_validate_certs value for quota creation which use the command line openstack client.

Could you consider to take my submission in consideration ?

JL